### PR TITLE
Encode Subject header field when containing none ASCII characters

### DIFF
--- a/tests/multiple_recipients.R
+++ b/tests/multiple_recipients.R
@@ -25,7 +25,7 @@ sendmail(from="from@example.org",
          subject="foo",
          msg="bar",
          control=list(transport="debug"))
-         
+
 sendmail(from="from@example.org",
          to="to1@example.org",
          cc=c("cc1@example.org", "cc2@example.org"),
@@ -44,5 +44,11 @@ sendmail(from="from@example.org",
          to="to1@example.org",
          bcc=c("bcc1@example.org", "bcc2@example.org"),
          subject="foo",
+         msg="bar",
+         control=list(transport="debug"))
+
+sendmail(from="from@example.org",
+         to="to1@example.org",
+         subject="K\u00f6ln",
          msg="bar",
          control=list(transport="debug"))


### PR DESCRIPTION
Dear @olafmersmann. I have been using _sendmailR_ for several years now, so thanks a lot for making and maintaining this package! In my case emails are served by MS Exchange that does not seem cope very well with Subject header fields containing none ASCII characters. So far I have solved this by encoding the _subject_ argument before providing it to `sendmailR::sendmail()`.

Rather than fixing this locally and in case others experience the same issue this PR proposes relevant changes that you might want to consider. I have added a function that apply base64 encoding to the Subject header field along the lines of [RFC 2047](https://www.rfc-editor.org/rfc/rfc2047) (to the best of my ability). This function is used by `sendmail()` conditionally, _i.e._ only if the _subject_ argument actually contains none ASCII characters. I have also added a section of code in the _multiple_recipients.R_ file that can be run to demonstrate an encoded Subject header field.

I have not ventured into the daunting task of full scale testing, but I have used both [Mailtrap](https://mailtrap.io) and [MXTOOLBOX](https://mxtoolbox.com/EmailHeaders.aspx) to check the resulting output and I have not identified any relevant issues. The changes proposed here are also quite similar to my "local fix" that has served me well over a couple of years now. I am therefore confident that the changes proposed will work as expected. 