### PR TITLE
Optional curl backend for SMTP authentication and SSL/STARTTLS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,8 +19,10 @@ Authors@R: c(
 URL: https://github.com/olafmersmann/sendmailR
 BugReports: https://github.com/olafmersmann/sendmailR/issues
 Depends: R (>= 3.0.0)
-Imports: base64enc, curl (>= 4.0)
+Imports: base64enc
+Suggests: curl (>= 4.0), knitr, rmarkdown, htmltools
 License: GPL-2
 LazyData: yes
 Encoding: UTF-8
 RoxygenNote: 7.2.2
+VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: sendmailR
 Version: 1.3-2
 Title: Send Email Using R
-Description: Package contains a simple SMTP client which provides a
-        portable solution for sending email, including attachment, from
-        within R.
+Description: Package contains a simple SMTP client with minimal dependencies which 
+        provides a portable solution for sending email, including file attachments and inline html reports, 
+        from within R. SMTP Authentication and SSL/STARTTLS is implemented using curl.
 Authors@R: c(
         person("Olaf", "Mersmann", role=c("aut", "cre"),
                comment = c(ORCID = "0000-0002-7720-4939"),
@@ -19,7 +19,7 @@ Authors@R: c(
 URL: https://github.com/olafmersmann/sendmailR
 BugReports: https://github.com/olafmersmann/sendmailR/issues
 Depends: R (>= 3.0.0)
-Imports: base64enc
+Imports: base64enc, curl (>= 4.0)
 License: GPL-2
 LazyData: yes
 Encoding: UTF-8

--- a/R/sendmailR.r
+++ b/R/sendmailR.r
@@ -25,6 +25,7 @@
 }
 
 .get_recipients <- function(headers) {
+  # TODO: parse e-mail from "name <a@b.com>"
   res <- headers$To
   if (!is.null(headers$Cc)) {
     res <- c(res, headers$Cc)
@@ -141,15 +142,22 @@
   send_command("QUIT", 221)
 }
 
-.smtp_submit_mail_curl <- function(smtp_server, headers, curlopts = list(), 
-                                   msg, verbose=FALSE, use_ssl = "force") {
+.smtp_submit_mail_curl <- function(smtp_server, headers, curlopts = list(),
+                                   msg, verbose = FALSE) {
+  # Check if curl is installed.
+  if (!requireNamespace("curl", quietly = TRUE)) {
+    stop("sendmail: engine = \"curl\" needs the curl package installed. 
+         Please run: install.packages(\"curl\")", call. = FALSE)
+  }
 
   stopifnot(is.character(headers$From))
-  
+
   # remove options to prevent multiple matching arguments
-  curlopts <- setdiff(curlopts, 
-                      c("smtp_server", "mail_from", "mail_rcpt", 
-                        "message", "use_ssl", "verbose"))
+  curlopts <- setdiff(curlopts,
+                      c("smtp_server", "mail_from", "mail_rcpt",
+                        "message", "verbose"))
+  # Default to force
+  if (is.null(curlopts$use_ssl)) curlopts$use_ssl <- "force"
 
   from <- headers$From
   to <- .get_recipients(headers)
@@ -167,7 +175,6 @@
       mail_from = from,
       mail_rcpt = to,
       message = msg,
-      use_ssl = use_ssl,
       verbose = verbose,
       smtp_server = smtp_server),
     curlopts)
@@ -187,20 +194,23 @@
 ##' @param msg Body text of message or a list containing
 ##'   \code{\link{mime_part}} objects.
 ##' @param \dots ...
-##' @param use_curl Use curl for mail transport. Enable if you need STARTTLS/SSL 
-##' and/or SMTP authentication. See \code{\link[curl]{send_mail}}.
-##' @param use_ssl Only used with curl. Defaults to "force". 
-##' For more information see \code{\link[curl]{send_mail}}.
+##' @param engine One of: \itemize{
+##' \item{\code{"internal"} for the internal smtp transport (default).}
+##' \item{\code{"curl"} for the use of curl for transport. Enable if you need STARTTLS/SSL
+##' and/or SMTP authentication. See \code{curl::\link[curl]{send_mail}}.}
+##' \item{\code{"debug"} sendmail returns a RFC2822 formatted email message without sending it.}
+##' }
 ##' @param headers Any other headers to include.
 ##' @param control List of SMTP server settings. Valid values are the
 ##'   possible options for \code{\link{sendmail_options}}.
-##' @param curlopts Options passed to curl if using the curl backend. 
-##' For authentication pass a list with \code{username} and \code{password}.
-##' For available options run \code{\link[curl]{curl_options}}. 
-##'
+##' @param engineopts Options passed to curl if using the curl backend. \itemize{
+##' \item{For authentication pass a list with \code{username} and \code{password}.}
+##' \item{\code{use_ssl} defaults to "force" if unset.}
+##' \item{For available options run \code{curl::\link[curl]{curl_options}}.}
+##' }
 ##' @seealso \code{\link{mime_part}} for a way to add attachments.
-##' 
-##' \code{\link[curl]{send_mail}} for curl SMTP URL specification.
+##'
+##' \code{curl::\link[curl]{send_mail}} for curl SMTP URL specification.
 ##' @keywords utilities
 ##'
 ##' @examples
@@ -211,22 +221,22 @@
 ##' body <- list("It works!", mime_part(iris))
 ##' sendmail(from, to, subject, body,
 ##'          control=list(smtpServer="ASPMX.L.GOOGLE.COM"))
-##' 
+##'
 ##' sendmail(from="from@example.org",
 ##'   to=c("to1@example.org", "to2@example.org"),
 ##'   subject="SMTP auth test",
 ##'   msg=mime_part("This message was send using sendmailR and curl."),
-##'   use_curl = TRUE,
-##'   curlopts = list(username = "foo", password = "bar"),
+##'   engine = "curl",
+##'   engineopts = list(username = "foo", password = "bar"),
 ##'   control=list(smtpServer="smtp://smtp.gmail.com:587", verbose = TRUE)
 ##' )
 ##' }
 ##' @export
 sendmail <- function(from, to, subject, msg, cc, bcc, ...,
-                     use_curl = FALSE, use_ssl = "force",
-                     headers=list(),
-                     control=list(),
-                     curlopts=list()) {
+                     engine     = c("internal", "curl", "debug"),
+                     headers    = list(),
+                     control    = list(),
+                     engineopts = list()) {
   ## Argument checks:
   stopifnot(is.list(headers), is.list(control))
   if (length(from) != 1)
@@ -235,7 +245,10 @@ sendmail <- function(from, to, subject, msg, cc, bcc, ...,
   if (length(to) < 1)
     stop("'to' must contain at least one address.")
 
-  get_value <- function(n, default="") {
+  # Uses the first element of vector
+  engine <- match.arg(engine, c("internal", "curl", "debug"))
+
+  get_value <- function(n, default = "") {
     if (n %in% names(control)) {
       return(control[[n]])
     } else if (n %in% names(.SendmailREnv$options)) {
@@ -244,6 +257,9 @@ sendmail <- function(from, to, subject, msg, cc, bcc, ...,
       return(default)
     }
   }
+
+  # For backward compatibility (2023-01-08 deprecated)
+  if (get_value("transport") == "debug") engine <- "debug"
 
   headers$From <- from
   headers$To <- to
@@ -264,25 +280,39 @@ sendmail <- function(from, to, subject, msg, cc, bcc, ...,
   if (is.null(headers$Date))
     headers$Date <- .rfc2822_date()
 
-  transport <- get_value("transport", "smtp")
   verbose <- get_value("verbose", FALSE)
-  if (transport == "smtp") {
-    server <- get_value("smtpServer", "localhost")
-    port <- get_value("smtpPort", 25)
+  server <- get_value("smtpServer", "localhost")
 
-    if (use_curl) {
-      # Add custom port to URL if none is specified using domain:port
-      if (!grepl(":", server) & (port != 25)) server <- paste0(server, ":", port)
-      
-      .smtp_submit_mail_curl(server, headers, curlopts, msg, 
-                             verbose = verbose, use_ssl = use_ssl)
-    } else {
-      # Default transport
-      .smtp_submit_mail(server, port, headers, msg, verbose)
+  if (engine == "curl") {
+    port <- get_value("smtpPort", 587)
+    # Add custom port to URL if none is specified using domain:port
+    # smtps:// uses port 465 by default
+    if (!grepl("[0-9]$", server) && !grepl("smtps:", server))
+      server <- paste0(server, ":", port)
+
+    return(
+      .smtp_submit_mail_curl(server, headers, curlopts = engineopts, msg,
+                             verbose = verbose))
     }
-    
-  } else if (transport == "debug") {
-    message("Recipients: ", paste(.get_recipients(headers), collapse=", "))
-    .write_mail(headers, msg, stderr())
+
+  if (engine == "internal") {
+    port <- get_value("smtpPort", 25)
+    # Default transport
+    return(
+      .smtp_submit_mail(server, port, headers, msg, verbose))
+  }
+
+  if (engine == "debug") {
+    message("Recipients: ", paste(.get_recipients(headers), collapse = ", "))
+
+    # use temporary file for .write_mail
+    sock <- file(tempfile(), open = "a+")
+    .write_mail(headers, msg, sock)
+    msg <- readLines(sock)
+    # Delete temp file
+    close(sock)
+    unlink(sock)
+
+    return(msg)
   }
 }

--- a/README.md
+++ b/README.md
@@ -2,11 +2,33 @@
 
 <!-- badges: start -->
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/olafmersmann/sendmailR)](https://lifecycle.r-lib.org/articles/stages.html)
-[![CRAN status](https://www.r-pkg.org/badges/version/sendmailR)](https://CRAN.R-project.org/package=sendmailR)
-[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/sendmailR)](https://CRAN.R-project.org/package=sendmailR)
+[![CRAN status](https://www.r-pkg.org/badges/version/sendmailR)](https://CRAN.R-project.org/package=sendmailR) 
+[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/sendmailR)](https://CRAN.R-project.org/package=sendmailR) 
+[![CRAN Downloads](http://cranlogs.r-pkg.org/badges/grand-total/sendmailR)](https://CRAN.R-project.org/package=sendmailR)
 <!-- badges: end -->
 
-Package contains a simple SMTP client which provides a portable solution for sending email, including attachment, from within [R].
+Package contains a simple SMTP client with minimal dependencies which provides a portable solution for sending email, including file attachments and inline html reports, from within [R](https://www.r-project.org/). SMTP Authentication and SSL/STARTTLS is implemented using curl.
+
+## Usage
+
+``` r
+from <- sprintf("<sendmailR@@\%s>", Sys.info()[4]) 
+to <- "<olafm@@datensplitter.net>" 
+subject <- "Hello from R" 
+body <- list("It works!", mime_part(iris)) 
+sendmail(from, to, subject, body, 
+  control=list(smtpServer="ASPMX.L.GOOGLE.COM")) 
+
+# With authentication and SSL
+sendmail(from="from@example.org", 
+  to=c("to1@example.org","to2@example.org"), 
+  subject="SMTP auth test", 
+  msg=mime_part("This message was send using sendmailR and curl."), 
+  engine = "curl", 
+  engineopts = list(username = "foo", password = "bar"), 
+  control=list(smtpServer="smtp://smtp.gmail.com:587", verbose = TRUE) 
+)
+```
 
 ## Install from github
 
@@ -23,5 +45,3 @@ Or using [`pak`](https://github.com/r-lib/pak):
 library("pak")
 pkg_install("olafmersmann/sendmailR")
 ```
-
-[R]: https://www.r-project.org/

--- a/man/sendmail.Rd
+++ b/man/sendmail.Rd
@@ -12,11 +12,10 @@ sendmail(
   cc,
   bcc,
   ...,
-  use_curl = FALSE,
-  use_ssl = "force",
+  engine = c("internal", "curl", "debug"),
   headers = list(),
   control = list(),
-  curlopts = list()
+  engineopts = list(use_ssl = "force")
 )
 }
 \arguments{
@@ -35,20 +34,23 @@ sendmail(
 
 \item{\dots}{...}
 
-\item{use_curl}{Use curl for mail transport. Enable if you need STARTTLS/SSL 
-and/or SMTP authentication. See \code{\link[curl]{send_mail}}.}
-
-\item{use_ssl}{Only used with curl. Defaults to "force". 
-For more information see \code{\link[curl]{send_mail}}.}
+\item{engine}{One of: \itemize{
+\item{\code{"internal"} for the internal smtp transport (default).}
+\item{\code{"curl"} for the use of curl for transport. Enable if you need STARTTLS/SSL
+and/or SMTP authentication. See \code{curl::\link[curl]{send_mail}}.}
+\item{\code{"debug"} sendmail returns a RFC2822 formatted email message without sending it.}
+}}
 
 \item{headers}{Any other headers to include.}
 
 \item{control}{List of SMTP server settings. Valid values are the
 possible options for \code{\link{sendmail_options}}.}
 
-\item{curlopts}{Options passed to curl if using the curl backend. 
-For authentication pass a list with \code{username} and \code{password}.
-For available options run \code{\link[curl]{curl_options}}.}
+\item{engineopts}{Options passed to curl if using the curl backend. \itemize{
+\item{For authentication pass a list with \code{username} and \code{password}.}
+\item{\code{use_ssl} defaults to "force" if unset.}
+\item{For available options run \code{curl::\link[curl]{curl_options}}.}
+}}
 }
 \description{
 Simplistic sendmail utility for R. Uses SMTP to submit a message
@@ -67,8 +69,8 @@ sendmail(from="from@example.org",
   to=c("to1@example.org", "to2@example.org"),
   subject="SMTP auth test",
   msg=mime_part("This message was send using sendmailR and curl."),
-  use_curl = TRUE,
-  curlopts = list(username = "foo", password = "bar"),
+  engine = "curl",
+  engineopts = list(username = "foo", password = "bar"),
   control=list(smtpServer="smtp://smtp.gmail.com:587", verbose = TRUE)
 )
 }
@@ -76,6 +78,6 @@ sendmail(from="from@example.org",
 \seealso{
 \code{\link{mime_part}} for a way to add attachments.
 
-\code{\link[curl]{send_mail}} for curl SMTP URL specification.
+\code{curl::\link[curl]{send_mail}} for curl SMTP URL specification.
 }
 \keyword{utilities}

--- a/man/sendmail.Rd
+++ b/man/sendmail.Rd
@@ -12,8 +12,11 @@ sendmail(
   cc,
   bcc,
   ...,
+  use_curl = FALSE,
+  use_ssl = "force",
   headers = list(),
-  control = list()
+  control = list(),
+  curlopts = list()
 )
 }
 \arguments{
@@ -32,10 +35,20 @@ sendmail(
 
 \item{\dots}{...}
 
+\item{use_curl}{Use curl for mail transport. Enable if you need STARTTLS/SSL 
+and/or SMTP authentication. See \code{\link[curl]{send_mail}}.}
+
+\item{use_ssl}{Only used with curl. Defaults to "force". 
+For more information see \code{\link[curl]{send_mail}}.}
+
 \item{headers}{Any other headers to include.}
 
 \item{control}{List of SMTP server settings. Valid values are the
 possible options for \code{\link{sendmail_options}}.}
+
+\item{curlopts}{Options passed to curl if using the curl backend. 
+For authentication pass a list with \code{username} and \code{password}.
+For available options run \code{\link[curl]{curl_options}}.}
 }
 \description{
 Simplistic sendmail utility for R. Uses SMTP to submit a message
@@ -49,10 +62,20 @@ subject <- "Hello from R"
 body <- list("It works!", mime_part(iris))
 sendmail(from, to, subject, body,
          control=list(smtpServer="ASPMX.L.GOOGLE.COM"))
-}
 
+sendmail(from="from@example.org",
+  to=c("to1@example.org", "to2@example.org"),
+  subject="SMTP auth test",
+  msg=mime_part("This message was send using sendmailR and curl."),
+  use_curl = TRUE,
+  curlopts = list(username = "foo", password = "bar"),
+  control=list(smtpServer="smtp://smtp.gmail.com:587", verbose = TRUE)
+)
+}
 }
 \seealso{
 \code{\link{mime_part}} for a way to add attachments.
+
+\code{\link[curl]{send_mail}} for curl SMTP URL specification.
 }
 \keyword{utilities}

--- a/vignettes/sending-html-reports.Rmd
+++ b/vignettes/sending-html-reports.Rmd
@@ -1,0 +1,120 @@
+---
+title: "Sending HTML reports inline and as attachment created with knitr"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Sending HTML reports inline and as attachment created with knitr}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r echo = FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>", fig.width = 7, fig.height = 5, warning = FALSE, message = FALSE)
+if (!requireNamespace("rmarkdown", quietly = TRUE) ||
+    !requireNamespace("htmltools", quietly = TRUE)) {
+  knitr::opts_chunk$set(eval = FALSE, tidy = FALSE)
+}
+```
+
+This file shows a typical workflow for knitting *.Rmd* documents and sending them per E-Mail.
+
+First we have our **my_file.Rmd** which looks like this:
+
+````{=html}
+<pre>
+---
+title: '&#32;'
+output: 
+  html_document:
+    theme: null
+    highlight: null
+    mathjax: null
+---
+
+Hello everyone,\n
+
+here is a calculation.
+
+**2+2 =**
+
+`​``{r echo=FALSE}
+2+2
+`​``
+
+All the best
+</pre>
+````
+
+```{r include=FALSE}
+test.Rmd <- "---
+title: '&#32;'
+output: 
+  html_document:
+    theme: null
+    highlight: null
+    mathjax: null
+---
+
+Hello everyone,\n
+
+here is a calculation.
+
+**2+2 =**
+\```{r echo=FALSE}
+2+2
+
+\```
+
+All the best
+"
+writeLines(test.Rmd, con = "my_file.Rmd")
+```
+
+## Render your rmarkdown file
+
+```{r echo=TRUE, results = 'hide'}
+htmlout <- tempfile(fileext = ".html")
+
+rmarkdown::render(
+      input = "my_file.Rmd",
+      intermediates_dir = ".",
+      output_file = htmlout,
+    )
+```
+
+## This is the resulting HTML document
+
+```{r echo=FALSE, results='asis'}
+unlink("my_file.Rmd")
+htmltools::includeHTML(htmlout)
+```
+
+------------------------------------------------------------------------
+
+## Sending the html file per E-Mail
+
+We can now send the the resulting html file as A) an file attachment or B) inline HTML.
+
+### A) File attachment
+
+```{r}
+library(sendmailR)
+sendmail(from="from@example.org",
+         to="to1@example.org",
+         subject="File attachment",
+         msg=c(
+           mime_part("Hello everyone,\n here is the newest report.\n Bye"),
+           mime_part(htmlout, name = "report.html")),
+         engine = "debug")
+
+```
+
+### B) Inline HTML
+
+```{r message=TRUE}
+sendmail(from="from@example.org",
+       to="to1@example.org",
+       subject="Inline HTML",
+       msg=mime_part_html(htmlout),
+       engine = "debug")
+
+```


### PR DESCRIPTION
Hi @olafmersmann,

since I got familiar with the code I realized that you could integrate SSL/SARTTLS and SMTP AUTH with curl/libcurl. 

With this code, username/password authentication works perfectly. Tested with https://mailtrap.io/ and some real SMTP servers.

The code is written so that any authentication mechanism provided by curl can be used (NTLM or OAUTH) by passing the required parameter through `curlopts`, but these were not tested.

All code should be perfectly backwards compatible. 

curl is now a new dependency. If you like, this could be moved to suggests and the user could be requested to install it when he wants to use curl. This would allow keeping dependencies minimal, but the normal curl R package is probably installed in most libraries anyway.

Doing other authentication mechanisms by hand, like you did, would be possible, but there is no easy and safe way to handle SSL encryption. And `curl::send_mail` leaves creating RFC2822 formatted messages as an exercise for the user.

What do you think?

Greetings
Alex
